### PR TITLE
Fixing piston bug with negative minimum y for supporting min_y down to -64, matching vanilla

### DIFF
--- a/src/main/java/net/minegate/fr/moreblocks/mixin/PistonBlockMixin.java
+++ b/src/main/java/net/minegate/fr/moreblocks/mixin/PistonBlockMixin.java
@@ -27,7 +27,7 @@ public class PistonBlockMixin extends FacingBlock
     @Inject(at = @At("RETURN"), method = "isMovable")
     private static boolean isMovable(BlockState blockState, World world, BlockPos blockPos, Direction direction, boolean canBreak, Direction pistonDir, CallbackInfoReturnable<Boolean> cir)
     {
-        if (blockPos.getY() >= 0 && blockPos.getY() <= world.getHeight() - 1 && world.getWorldBorder().contains(blockPos))
+        if (blockPos.getY() >= world.getBottomY() && blockPos.getY() <= world.getHeight() - 1 && world.getWorldBorder().contains(blockPos))
         {
             if (blockState.isAir())
             {


### PR DESCRIPTION
Fix for min_y supporting negative y values in min_y, using miniumY instead of hard coded 0.
https://github.com/MrFantiVideo/MineGate/issues/15